### PR TITLE
Remove prepath

### DIFF
--- a/config.md
+++ b/config.md
@@ -23,5 +23,3 @@ Add here global latex commands to use throughout your pages.
 -->
 \newcommand{\R}{\mathbb R}
 \newcommand{\scal}[1]{\langle #1 \rangle}
-
-@def prepath = "JuliaClimate"


### PR DESCRIPTION
This is not necessary since the site is hosted on https://juliaclimate.org/ and not https://JuliaClimate.github.io/JuliaClimate.org/ or so