### PR TITLE
Allow PRs to be checked too

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
       - master
+  pull_request:
+  workflow_dispatch:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -38,6 +40,7 @@ jobs:
             using Franklin;
             optimize()'
     - name: Build and Deploy
+      if: ${{ github.event_name != 'pull_request' }}
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Might be useful if you plan to collaborate on this repo with multiple people. The `workflow_dispatch` is useful if you want to quickly rebuild the site for some reason (via the GitHub interface).